### PR TITLE
Send empty response to clientPin instead of empty map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `url` to `icon` in `PublicKeyCredentialRpEntity` and ignore its
   content ([#9][])
 - Truncate overlong `name` and `displayName` values for `PublicKeyCredentialEntity` instances ([#30][])
+- Send empty response to clientPin instead of empty map ([#13][])
 
 [#9]: https://github.com/solokeys/ctap-types/issues/9
 [#30]: https://github.com/solokeys/fido-authenticator/issues/30
+[#13]: https://github.com/solokeys/ctap-types/issues/13
 
 ## [0.1.2] - 2022-03-07
 

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -148,7 +148,13 @@ impl Response {
         let outcome = match self {
             GetInfo(response) => cbor_serialize(response, data),
             MakeCredential(response) => cbor_serialize(response, data),
-            ClientPin(response) => cbor_serialize(response, data),
+            ClientPin(response) => {
+                if response.is_empty() {
+                    Ok([].as_slice())
+                } else {
+                    cbor_serialize(response, data)
+                }
+            },
             GetAssertion(response) | GetNextAssertion(response) => cbor_serialize(response, data),
             CredentialManagement(response) => cbor_serialize(response, data),
             Reset | Selection | Vendor => Ok([].as_slice()),

--- a/src/ctap2/client_pin.rs
+++ b/src/ctap2/client_pin.rs
@@ -73,6 +73,12 @@ pub struct Response {
     pub retries: Option<u8>,
 }
 
+impl Response {
+    pub fn is_empty(&self) -> bool {
+        self.key_agreement.is_none() && self.pin_token.is_none() && self.retries.is_none()
+    }
+}
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
For the SetPin and ChangePin subcommands, the clientPin command does not return any parameters.  Previously, we sent an empty map for these cases.  With this patch, we sent an empty response instead.

Fixes: https://github.com/solokeys/ctap-types/issues/13