### PR TITLE
Add Deserialize to PublicKey (under 'allolc' feature)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctap-types"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Nicolas Stalder <n@stalder.io>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -21,13 +21,16 @@ iso7816 = "0.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-indexed = "0.1"
 serde_repr = "0.1"
+serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde = { version = "1" }
+serde_test = "1.0"
 
 [features]
 log-all = ["cbor-smol/log-all"]
 log-none = []
+alloc = ["serde/alloc", "serde_derive"]
 
 # [patch.crates-io]
 # heapless = { git = "https://github.com/nickray/heapless", branch = "bytebuf-0.5.6" }


### PR DESCRIPTION
See previous PR https://github.com/trussed-dev/cosey/pull/1, and @nickray's comment requesting this to be moved under an `alloc` feature (https://github.com/trussed-dev/cosey/pull/1#issuecomment-1499049387).

This PR does not add a non-alloc implementation of Deserialize for PublicKey, but this could be added later if needed.

## Tests

Default (no alloc):

```
$ cargo test
```
```
    Finished test [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/ctap_types-9141bc0158c49bee)

running 3 tests
test ctap2::client_pin::tests::pin_v1_subcommand ... ok
test webauthn::tests::test_truncate ... ok
test ctap2::make_credential::tests::rp_entity_icon ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/bennofs.rs (target/debug/deps/bennofs-076f21189ab5a5f9)

running 1 test
test test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/get_assertion.rs (target/debug/deps/get_assertion-b3ae8f5b55c10524)

running 8 tests
test test_allow_list ... ok
test test_client_data_hash ... ok
test test_extensions_hmac_secret_input ... ok
test test_extensions ... ok
test test_extensions_hmac_secret_input_key_agreement ... ok
test test_extensions_hmac_secret_salt_auth ... ok
test test_extensions_hmac_secret_salt_enc ... ok
test test_rp_id ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests ctap-types

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

With alloc feature:

```
$ cargo test --features alloc
```
```
    Finished test [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/ctap_types-67cbe68381549b4c)

running 7 tests
test cose::tests::deserialize_publickey_ecdheshkdf256 ... ok
test cose::tests::deserialize_publickey_ed25519key ... ok
test cose::tests::deserialize_publickey_totpkey ... ok
test cose::tests::deserialize_publickey_p256key ... ok
test ctap2::client_pin::tests::pin_v1_subcommand ... ok
test webauthn::tests::test_truncate ... ok
test ctap2::make_credential::tests::rp_entity_icon ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/bennofs.rs (target/debug/deps/bennofs-3a8b0f0dd7cf5b89)

running 1 test
test test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/get_assertion.rs (target/debug/deps/get_assertion-13496925ebfe5ecb)

running 8 tests
test test_allow_list ... ok
test test_client_data_hash ... ok
test test_extensions_hmac_secret_input ... ok
test test_extensions ... ok
test test_extensions_hmac_secret_input_key_agreement ... ok
test test_extensions_hmac_secret_salt_auth ... ok
test test_extensions_hmac_secret_salt_enc ... ok
test test_rp_id ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests ctap-types

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```
