### PR TITLE
Enable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build library
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Build library
+      run: cargo build
+
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Run tests
+      run: cargo test
+
+  clippy:
+    name: Run clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: "clippy"
+    - name: Run clippy
+      run: cargo clippy -- -D warnings
+
+  fmt:
+    name: Run rustfmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: "rustfmt"
+    - name: Run rustfmt
+      run: cargo fmt -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use references rather owned byte vectors to reduce the size of structs ([#16][])
 - Accept more than 12 algorithms ([#17][])
 - Add support for the `largeBlobKey` extension ([#18][])
+- Remove `AuthenticatorDataFlags::EMPTY` (use `AuthenticatorDataFlags::empty()` instead)
 
 [#9]: https://github.com/solokeys/ctap-types/issues/9
 [#30]: https://github.com/solokeys/fido-authenticator/issues/30

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -158,7 +158,7 @@ impl Response {
                 } else {
                     cbor_serialize(response, data)
                 }
-            },
+            }
             GetAssertion(response) | GetNextAssertion(response) => cbor_serialize(response, data),
             CredentialManagement(response) => cbor_serialize(response, data),
             LargeBlobs(response) => cbor_serialize(response, data),
@@ -281,7 +281,6 @@ pub struct AuthenticatorOptions {
 
 bitflags! {
     pub struct AuthenticatorDataFlags: u8 {
-        const EMPTY = 0;
         const USER_PRESENCE = 1 << 0;
         const USER_VERIFIED = 1 << 2;
         const ATTESTED_CREDENTIAL_DATA = 1 << 6;

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -12,23 +12,18 @@ use crate::{
 type Bytes16 = Bytes<16>;
 type Bytes32 = Bytes<32>;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
 // #[derive(Clone,Debug,Eq,PartialEq,Serialize, Deserialize)]
 // #[serde(tag = "credProtect")]
 #[repr(u8)]
 pub enum CredentialProtectionPolicy {
     // #[serde(rename = "userVerificationOptional")]
+    #[default]
     Optional = 1,
     // #[serde(rename = "userVerificationOptionalWithCredentialIDList")] // <-- len = 44
     OptionalWithCredentialIdList = 2,
     // #[serde(rename = "userVerificationRequired")]
     Required = 3,
-}
-
-impl core::default::Default for CredentialProtectionPolicy {
-    fn default() -> Self {
-        CredentialProtectionPolicy::Optional
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]


### PR DESCRIPTION
This patch adds a CI config that builds and tests the library and runs clippy and rustfmt.  To make the CI pass, it also fixes the formatting and two clippy lints.  One of them is a breaking change:  We remove AuthenticatorDataFlags::EMPTY.  Instead, AuthenticatorDataFlags::empty() should be used.