### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+[Unreleased]: https://github.com/trussed-dev/ctap-types/compare/0.2.0...HEAD
+
+-
+
+## [0.2.0] - 2024-06-21
+
+[0.2.0]: https://github.com/trussed-dev/ctap-types/compare/0.1.2...0.2.0
+
 - Rename `url` to `icon` in `PublicKeyCredentialRpEntity` and ignore its
   content ([#9][])
 - Truncate overlong `name` and `displayName` values for `PublicKeyCredentialEntity` instances ([#30][])
@@ -39,9 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.2] - 2022-03-07
 
+[0.1.2]: https://github.com/trussed-dev/ctap-types/compare/0.1.1...0.1.2
+
 Yanked 0.1.1 instead of 0.1.0 by mistake, re-releasing.
 
 ## [0.1.1] - 2022-03-07
+
+[0.1.1]: https://github.com/trussed-dev/ctap-types/compare/0.1.0...0.1.1
 
 - add CTAP2.1 Selection command
 - add CTAP2.1 options
@@ -49,6 +61,8 @@ Yanked 0.1.1 instead of 0.1.0 by mistake, re-releasing.
 We will release this and yank 0.1.0, to avoid a minor version bump.
 
 ## [0.1.0] - 2022-03-05
+
+[0.1.0]: https://github.com/trussed-dev/ctap-types/releases/tag/0.1.0
 
 - use 2021 edition
 - make CTAP1 and CTAP2 more homogeneous

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ctap-types"
-version = "0.1.2"
-authors = ["Nicolas Stalder <n@stalder.io>"]
+version = "0.2.0"
+authors = ["Nicolas Stalder <n@stalder.io>", "The Trussed developers"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "no_std friendly types for FIDO CTAP"
-homepage = "https://github.com/solokeys/ctap-types"
+repository = "https://github.com/trussed-dev/ctap-types"
 
 [dependencies]
 bitflags = "1.3"
@@ -16,8 +16,8 @@ heapless = { version = "0.7", default-features = false, features = ["serde"] }
 heapless-bytes = "0.3"
 iso7816 = "0.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde-indexed = "0.1"
-serde_bytes = { version = "0.11.12", default-features = false }
+serde-indexed = "0.1.1"
+serde_bytes = { version = "0.11.14", default-features = false }
 serde_repr = "0.1"
 
 [features]
@@ -26,8 +26,9 @@ get-info-full = []
 # enables support for implementing the large-blobs extension, see src/sizes.rs
 large-blobs = []
 
-log-all = ["cbor-smol/log-all"]
+log-all = []
 log-none = []
-
-[patch.crates-io]
-serde-indexed = { git = "https://github.com/trussed-dev/serde-indexed.git", rev = "d95cbe064ef0bfd0ce2d01582110e29fbc22afbd" }
+log-info = []
+log-debug = []
+log-warn = []
+log-error = []


### PR DESCRIPTION
To do:
- [x] https://github.com/trussed-dev/ctap-types/pull/8
- [x] https://github.com/trussed-dev/ctap-types/pull/20
- [x] bump serde-indexed
- [x] replace homepage with repository in Cargo.toml
- [x] fix delog features