### PR TITLE
 Ignore more unknown keys in cose deserialization 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use references rather owned byte vectors to reduce the size of structs ([#16][])
 - Accept more than 12 algorithms ([#17][])
 - Add support for the `largeBlobKey` extension ([#18][])
+- Allow missing algorithms in COSE keys ([#8][])
 
+[#8]: https://github.com/trussed-dev/ctap-types/pull/8
 [#9]: https://github.com/solokeys/ctap-types/issues/9
 [#30]: https://github.com/solokeys/fido-authenticator/issues/30
 [#13]: https://github.com/solokeys/ctap-types/issues/13

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,5 @@ log-none = []
 
 [patch.crates-io]
 # heapless = { git = "https://github.com/nickray/heapless", branch = "bytebuf-0.5.6" }
+cbor-smol = { git = "https://github.com/sosthene-nitrokey/cbor-smol.git", branch = "ignored-any" }
 serde-indexed = { git = "https://github.com/sosthene-nitrokey/serde-indexed.git", rev = "5005d23cb4ee8622e62188ea0f9466146f851f0d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ serde_bytes = { version = "0.11.12", default-features = false }
 serde_repr = "0.1"
 
 [dev-dependencies]
+ciborium = "0.2.1"
+hex = "0.4.3"
+itertools = "0.12.0"
+quickcheck = "1.0.3"
 serde = { version = "1" }
 
 [features]

--- a/src/cose.rs
+++ b/src/cose.rs
@@ -422,12 +422,13 @@ fn check_key_constants<K: PublicKeyConstants, E: serde::de::Error>(
     crv: Option<Crv>,
 ) -> Result<(), E> {
     let kty = kty.ok_or_else(|| E::missing_field("kty"))?;
-    let alg = alg.ok_or_else(|| E::missing_field("alg"))?;
     if kty != K::KTY {
         return Err(E::invalid_value(Unexpected::Signed(kty as _), &K::KTY));
     }
-    if alg != K::ALG {
-        return Err(E::invalid_value(Unexpected::Signed(alg as _), &K::ALG));
+    if let Some(alg) = alg {
+        if alg != K::ALG {
+            return Err(E::invalid_value(Unexpected::Signed(alg as _), &K::ALG));
+        }
     }
     if K::CRV != Crv::None {
         let crv = crv.ok_or_else(|| E::missing_field("crv"))?;

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -158,7 +158,7 @@ impl Response {
                 } else {
                     cbor_serialize(response, data)
                 }
-            },
+            }
             GetAssertion(response) | GetNextAssertion(response) => cbor_serialize(response, data),
             CredentialManagement(response) => cbor_serialize(response, data),
             LargeBlobs(response) => cbor_serialize(response, data),

--- a/tests/cose.rs
+++ b/tests/cose.rs
@@ -129,6 +129,10 @@ fn test_de_order<T: Serialize + DeserializeOwned + Debug + PartialEq>(data: T) -
     }
 
     let mut fields = canonical_fields;
+    fields.insert(
+        2,
+        (Value::Integer(2.into()), Value::Text("foobar".to_owned())),
+    );
     fields.push((Value::Integer(42.into()), Value::Text("foobar".to_owned())));
     fields.push((Value::Integer(24.into()), Value::Text("foobar".to_owned())));
     let (deserialized, serialized) = deserialize_map::<T>(fields);

--- a/tests/cose.rs
+++ b/tests/cose.rs
@@ -1,0 +1,169 @@
+use cbor_smol::{cbor_deserialize, cbor_serialize_bytes};
+use ciborium::Value;
+use core::fmt::Debug;
+use ctap_types::cose::{EcdhEsHkdf256PublicKey, Ed25519PublicKey, P256PublicKey};
+use heapless_bytes::Bytes;
+use itertools::Itertools as _;
+use quickcheck::{Arbitrary, Gen};
+use serde::{de::DeserializeOwned, Serialize};
+
+#[derive(Clone, Debug)]
+struct Input(Bytes<32>);
+
+impl Arbitrary for Input {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let mut data = vec![0; 32];
+        data.fill_with(|| u8::arbitrary(g));
+        Self(Bytes::from_slice(&data).unwrap())
+    }
+}
+
+fn deserialize_map<T: DeserializeOwned>(
+    map: Vec<(Value, Value)>,
+) -> (Result<T, cbor_smol::Error>, Vec<u8>) {
+    let map = Value::Map(map);
+    let mut serialized: Vec<u8> = Default::default();
+    ciborium::into_writer(&map, &mut serialized).unwrap();
+    (cbor_deserialize(&serialized), serialized)
+}
+
+fn print_input_output<T: Debug + PartialEq>(
+    input: &T,
+    serialized: &[u8],
+    deserialized: &Result<T, cbor_smol::Error>,
+) {
+    println!("serialized:\n  {}", hex::encode(serialized));
+    println!("input:\n     {:?}", input);
+    print!("deserialized:\n  ");
+    if deserialized.as_ref() == Ok(input) {
+        println!("Ok(input)");
+    } else {
+        println!("{:?}", deserialized);
+    }
+}
+
+fn test_serde<T: Serialize + DeserializeOwned + PartialEq>(data: T) -> bool {
+    let serialized: Bytes<1024> = cbor_serialize_bytes(&data).unwrap();
+    let deserialized: T = cbor_deserialize(&serialized).unwrap();
+    data == deserialized
+}
+
+fn test_de<T: DeserializeOwned + Debug + PartialEq>(s: &str, data: T) {
+    let serialized = hex::decode(s).unwrap();
+    let deserialized: T = cbor_deserialize(&serialized).unwrap();
+    assert_eq!(data, deserialized);
+}
+
+fn test_de_order<T: Serialize + DeserializeOwned + Debug + PartialEq>(data: T) -> bool {
+    let serialized_value = Value::serialized(&data).unwrap();
+    let canonical_fields = serialized_value.into_map().unwrap();
+
+    for fields in canonical_fields
+        .iter()
+        .cloned()
+        .permutations(canonical_fields.len())
+    {
+        let is_canonical = fields == canonical_fields;
+        let (deserialized, serialized) = deserialize_map::<T>(fields);
+
+        // only the canonical order should be accepted
+        let is_success = if is_canonical {
+            Ok(&data) == deserialized.as_ref()
+        } else {
+            deserialized.is_err()
+        };
+
+        if !is_success {
+            if is_canonical {
+                println!("Expected correct deserialization for canonical order");
+            } else {
+                println!("Expected error for non-canonical order");
+            }
+            print_input_output(&data, &serialized, &deserialized);
+            return false;
+        }
+    }
+
+    let mut fields = canonical_fields;
+    fields.push((Value::Integer(42.into()), Value::Text("foobar".to_owned())));
+    fields.push((Value::Integer(24.into()), Value::Text("foobar".to_owned())));
+    let (deserialized, serialized) = deserialize_map::<T>(fields);
+
+    // injecting an unsupported field should not change the result
+    let is_success = Ok(&data) == deserialized.as_ref();
+
+    if !is_success {
+        println!("Expected correct deserialization with unsupported fields");
+        print_input_output(&data, &serialized, &deserialized);
+    }
+
+    is_success
+}
+
+#[test]
+fn de_p256() {
+    let x = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let y = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let key = P256PublicKey { x, y };
+    test_de("a5010203262001215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff225820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", key);
+}
+
+#[test]
+fn de_ecdh() {
+    let x = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let y = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let key = EcdhEsHkdf256PublicKey { x, y };
+    test_de("a501020338182001215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff225820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", key);
+}
+
+#[test]
+fn de_ed25519() {
+    let x = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let key = Ed25519PublicKey { x };
+    test_de(
+        "a4010103272006215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        key,
+    );
+}
+
+quickcheck::quickcheck! {
+    fn serde_p256(x: Input, y: Input) -> bool {
+        test_serde(P256PublicKey {
+            x: x.0,
+            y: y.0,
+        })
+    }
+
+    fn serde_ecdh(x: Input, y: Input) -> bool {
+        test_serde(EcdhEsHkdf256PublicKey {
+            x: x.0,
+            y: y.0,
+        })
+    }
+
+    fn serde_ed25519(x: Input) -> bool {
+        test_serde(Ed25519PublicKey {
+            x: x.0,
+        })
+    }
+
+    fn de_order_p256(x: Input, y: Input) -> bool {
+        test_de_order(P256PublicKey {
+            x: x.0,
+            y: y.0,
+        })
+    }
+
+    fn de_order_ecdh(x: Input, y: Input) -> bool {
+        test_de_order(EcdhEsHkdf256PublicKey {
+            x: x.0,
+            y: y.0,
+        })
+    }
+
+    fn de_order_ed25519(x: Input) -> bool {
+        test_de_order(Ed25519PublicKey {
+            x: x.0,
+        })
+    }
+}


### PR DESCRIPTION
Using cbor-smol’s new deserialize_any implementation, we can now iterate
over all keys and values in the input map and ignore all unknown keys,
as required by the spec.

Built on top of https://github.com/trussed-dev/ctap-types/pull/8 using https://github.com/nickray/cbor-smol/pull/6.