### PR TITLE
Replace empty maps with an empty response

### DIFF
--- a/src/ctap2/client_pin.rs
+++ b/src/ctap2/client_pin.rs
@@ -73,12 +73,6 @@ pub struct Response {
     pub retries: Option<u8>,
 }
 
-impl Response {
-    pub fn is_empty(&self) -> bool {
-        self.key_agreement.is_none() && self.pin_token.is_none() && self.retries.is_none()
-    }
-}
-
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
Instead of sending an empty CBOR map as a response, we now always send an empty response.  Previously, we had this as a special case for the ClientPin response, but we need it for LargeBlobs too.  So a generic implementation makes more sense and is easier to maintain.