### PR TITLE
Fix buffer size in large-blobs response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for the `largeBlobKey` extension ([#18][])
 - Remove `AuthenticatorDataFlags::EMPTY` (use `AuthenticatorDataFlags::empty()` instead)
 - Allow missing algorithms in COSE keys ([#8][])
+- Remove unused `REALISTIC_MAX_MESSAGE_SIZE` constant
 
 [#8]: https://github.com/trussed-dev/ctap-types/pull/8
 [#9]: https://github.com/solokeys/ctap-types/issues/9

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ quickcheck = "1.0.3"
 serde = { version = "1" }
 
 [features]
+# enables support for implementing the large-blobs extension, see src/sizes.rs
+large-blobs = []
+
 log-all = ["cbor-smol/log-all"]
 log-none = []
 

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -21,10 +21,7 @@ pub const PACKET_SIZE: usize = 64;
 /// The theoretical maximal message size, which however is far
 /// too large for most platforms.
 pub const THEORETICAL_MAX_MESSAGE_SIZE: usize = PACKET_SIZE - 7 + 128 * (PACKET_SIZE - 5);
-/// The size used by Yubico, which means that no platforms will
-/// realistically expect a larger size.
-pub const REALISTIC_MAX_MESSAGE_SIZE: usize = 1200;
 
 /// Max length for a large blob fragment, according to
 /// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#largeBlobsRW
-pub const LARGE_BLOB_MAX_FRAGMENT_LENGTH: usize = REALISTIC_MAX_MESSAGE_SIZE - 64;
+pub const LARGE_BLOB_MAX_FRAGMENT_LENGTH: usize = 1200 - 64;

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -24,4 +24,13 @@ pub const THEORETICAL_MAX_MESSAGE_SIZE: usize = PACKET_SIZE - 7 + 128 * (PACKET_
 
 /// Max length for a large blob fragment, according to
 /// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#largeBlobsRW
-pub const LARGE_BLOB_MAX_FRAGMENT_LENGTH: usize = 1200 - 64;
+///
+/// This constant determines the buffer size in [`ctap2::large_blobs::Response`][].  Ideally, this
+/// would be configurable.  Currently, this is not possible.  To keep the stack usage low if the
+/// extension is not used, this constant defaults to zero. For compatibility with the max message
+/// size in usbd-ctaphid (used by solo2 and nitrokey-3-firmware), it is set to 3072 - 64 =
+/// 3008 if the `large-blobs` feature is enabled.
+#[cfg(not(feature = "large-blobs"))]
+pub const LARGE_BLOB_MAX_FRAGMENT_LENGTH: usize = 0;
+#[cfg(feature = "large-blobs")]
+pub const LARGE_BLOB_MAX_FRAGMENT_LENGTH: usize = 3008;


### PR DESCRIPTION
The buffer size used in the response to the large-blobs command should match the maximum message size of the FIDO2 implementation (minus 64). At the same time, the buffer size must be hardcoded because serde-indexed does not support const generics.  As a temporary workaround, this PR changes the default buffer size to zero (to reduce stack usage if the extension is not used) and sets the buffer size to 3008 if the large-blobs feature is activated (matching the max message size declared by usbd-ctaphid that is used in solo2 and nitrokey-3-firmware).

This PR also removes the `REALISTIC_MAX_MESSAGE_SIZE` as it is unused in `ctap-types` and does not have any significance for other crates either.