### PR TITLE
Add support for PIN protocol 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow missing algorithms in COSE keys ([#8][])
 - Remove unused `REALISTIC_MAX_MESSAGE_SIZE` constant
 - Handle overlong `icon` values in `PublicKeyCredentialUserEntity` ([#27][])
+- Update for compatibility with PIN protocol 2
 
 [#8]: https://github.com/trussed-dev/ctap-types/pull/8
 [#9]: https://github.com/solokeys/ctap-types/issues/9

--- a/src/ctap2/client_pin.rs
+++ b/src/ctap2/client_pin.rs
@@ -43,18 +43,18 @@ pub struct Request {
     // First 16 bytes of HMAC-SHA-256 of encrypted contents
     // using `sharedSecret`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pin_auth: Option<Bytes<16>>,
+    pub pin_auth: Option<Bytes<256>>,
 
     // 0x05
     // Encrypted new PIN using `sharedSecret`.
     // (Encryption over UTF-8 representation of new PIN).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub new_pin_enc: Option<Bytes<64>>,
+    pub new_pin_enc: Option<Bytes<80>>,
 
     // 0x06
     // Encrypted first 16 bytes of SHA-256 of PIN using `sharedSecret`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pin_hash_enc: Option<Bytes<64>>,
+    pub pin_hash_enc: Option<Bytes<80>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, SerializeIndexed, DeserializeIndexed)]
@@ -66,7 +66,7 @@ pub struct Response {
 
     // 0x02, encrypted `pinToken` using `sharedSecret`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pin_token: Option<Bytes<32>>,
+    pub pin_token: Option<Bytes<48>>,
 
     // 0x03, number of PIN attempts remaining before lockout
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -9,7 +9,6 @@ use crate::{
     Bytes,
 };
 
-type Bytes16 = Bytes<16>;
 type Bytes32 = Bytes<32>;
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
@@ -61,7 +60,7 @@ pub struct Request {
     pub pin_protocol: Option<u8>,
     // 0x04
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pin_auth: Option<Bytes16>,
+    pub pin_auth: Option<Bytes<256>>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, SerializeIndexed)]

--- a/src/ctap2/get_assertion.rs
+++ b/src/ctap2/get_assertion.rs
@@ -19,7 +19,7 @@ use crate::webauthn::*;
 pub struct HmacSecretInput {
     pub key_agreement: EcdhEsHkdf256PublicKey,
     // *either* enc(salt1) *or* enc(salt1 || salt2)
-    pub salt_enc: Bytes<64>,
+    pub salt_enc: Bytes<80>,
     pub salt_auth: Bytes<16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pin_protocol: Option<u32>,
@@ -41,7 +41,7 @@ pub struct ExtensionsOutput {
     #[serde(rename = "hmac-secret")]
     #[serde(skip_serializing_if = "Option::is_none")]
     // *either* enc(output1) *or* enc(output1 || output2)
-    pub hmac_secret: Option<Bytes<64>>,
+    pub hmac_secret: Option<Bytes<80>>,
 }
 
 pub struct NoAttestedCredentialData(core::marker::PhantomData<()>);


### PR DESCRIPTION
This means that all encrypted values need additional 16 bytes for the IV, and the PIN hash is now completely transmitted instead of truncating it to 16 bytes.