### PR TITLE
make_credential: Make att_stmt optional in Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use references where possible
 - Put uncommon fields in `get_info` behind `get-info-full` feature flag and add fields for CTAP 2.1
 - Use byte arrays instead of slices or Bytes<_> where possible
+- Make `att_stmt` optional in `make_credential::Response`, preparing for CTAP 2.2
 
 [#8]: https://github.com/trussed-dev/ctap-types/pull/8
 [#9]: https://github.com/solokeys/ctap-types/issues/9

--- a/src/ctap2/make_credential.rs
+++ b/src/ctap2/make_credential.rs
@@ -105,7 +105,8 @@ impl<'a> super::SerializeAttestedCredentialData for AttestedCredentialData<'a> {
 pub struct Response {
     pub fmt: String<32>,
     pub auth_data: super::SerializedAuthenticatorData,
-    pub att_stmt: AttestationStatement,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub att_stmt: Option<AttestationStatement>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ep_att: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -116,7 +117,6 @@ pub struct Response {
 pub struct ResponseBuilder {
     pub fmt: String<32>,
     pub auth_data: super::SerializedAuthenticatorData,
-    pub att_stmt: AttestationStatement,
 }
 
 impl ResponseBuilder {
@@ -125,7 +125,7 @@ impl ResponseBuilder {
         Response {
             fmt: self.fmt,
             auth_data: self.auth_data,
-            att_stmt: self.att_stmt,
+            att_stmt: None,
             ep_att: None,
             large_blob_key: None,
         }


### PR DESCRIPTION
In CTAP 2.2, att_stmt will be optional in the make_credential response. Applying this change now allows us to release v0.2.0 and then add the remaining (compatible) changes required for CTAP 2.2 in a patch release.