### PR TITLE
Use enums instead of string constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/trussed-dev/ctap-types/compare/0.2.0...HEAD
 
--
+### Breaking Changes
+
+- Use enums instead of string constants
+  - Introduce `Version`, `Extension` and `Transport` enums and use them in `ctap2::get_info`
+  - Fix serialization of the `AttestationStatementFormat` enum and use it in `ctap2::make_credential`
 
 ## [0.2.0] - 2024-06-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ serde-indexed = "0.1.1"
 serde_bytes = { version = "0.11.14", default-features = false }
 serde_repr = "0.1"
 
+[dev-dependencies]
+serde_test = "1.0.176"
+
 [features]
 # enables all fields for ctap2::get_info
 get-info-full = []

--- a/src/ctap2/make_credential.rs
+++ b/src/ctap2/make_credential.rs
@@ -189,6 +189,7 @@ pub struct PackedAttestationStatement {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_test::{assert_ser_tokens, Token};
 
     #[test]
     fn rp_entity_icon() {
@@ -199,5 +200,16 @@ mod tests {
         // previously, we called it `url` and should still be able to deserialize it
         let cbor = b"\xa4\x01X \xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\x02\xa2bidx0make_credential_relying_party_entity.example.comcurlohttp://icon.png\x03\xa2bidX \x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1ddnamedAdam\x04\x81\xa2calg&dtypejpublic-key";
         let _request: Request = cbor_smol::cbor_deserialize(cbor.as_slice()).unwrap();
+    }
+
+    #[test]
+    fn test_serde_attestation_statement_format() {
+        let formats = [
+            (AttestationStatementFormat::None, "none"),
+            (AttestationStatementFormat::Packed, "packed"),
+        ];
+        for (format, s) in formats {
+            assert_ser_tokens(&format, &[Token::BorrowedStr(s)]);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,19 @@ pub mod webauthn;
 
 pub use ctap2::{Error, Result};
 
+use core::fmt::{self, Display, Formatter};
+
+/// An error returned by the `TryFrom<&str>` implementation for enums if an invalid value is
+/// provided.
+#[derive(Debug)]
+pub struct TryFromStrError;
+
+impl Display for TryFromStrError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        "invalid enum value".fmt(f)
+    }
+}
+
 #[cfg(test)]
 mod tests {}
 


### PR DESCRIPTION
Previously, we used `String<_>` to represent string constants in some responses.  This has multiple drawbacks:
- It is error-prone because the value is not validated.
- Construction is fallible because of the fixed length of the string.
- The length needs to be bumped if longer values are added.

This patch introduces enums to replace these constants.  As `cbor_smol` serializes enums using the variant index instead of the string, we need to manually implement the string conversion.