### PR TITLE
Implement Copy for ctap2::AttestationStatementFormat

### DIFF
--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -259,7 +259,7 @@ pub enum AttestationStatement {
     Packed(PackedAttestationStatement),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 #[serde(into = "&str", try_from = "&str")]


### PR DESCRIPTION
This change was accidentally removed from https://github.com/trussed-dev/ctap-types/pull/51 during a rebase.